### PR TITLE
Yii2 Froala Plugin, Update in accordance with Froala PHP SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Either run
 ```
 php composer.phar require --prefer-dist froala/yii2-froala-editor
 php composer.phar require --prefer-dist froala/wysiwyg-editor-php-sdk
+php composer.phar require --prefer-dist bower-asset/froala-wysiwyg-editor
 
 ```
 
@@ -22,7 +23,8 @@ or add
 
 ```
 "froala/yii2-froala-editor": "^2.6.0",
-"froala/wysiwyg-editor-php-sdk" : "*"
+"froala/wysiwyg-editor-php-sdk" : "*",
+"bower-asset/froala-wysiwyg-editor": "^2.6.0"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,23 @@
 
 ## Installation
 
-The preferred way to install this extension is through [composer](http://getcomposer.org/download/).
+The preferred way to install this extension is through [composer](http://getcomposer.org/download/). yii2-froala editor depends on Froala PHP SDK
+To use and Install the editor, one must install PHP SDK also.
 
 Either run
 
 ```
 php composer.phar require --prefer-dist froala/yii2-froala-editor
+php composer.phar require --prefer-dist froala/wysiwyg-editor-php-sdk
+
 ```
 
 or add
 
 ```
-"froala/yii2-froala-editor": "^2.6.0"
+"froala/yii2-froala-editor": "^2.6.0",
+"froala/wysiwyg-editor-php-sdk" : "*"
+
 ```
 
 to the require section of your `composer.json` file.
@@ -63,65 +68,19 @@ or use with a model:
 
 ## Upload example
 
-Using the basic Yii template make a new folder under /web/ called uploads.
-
-For controler: 
-
-```php
-public function actionUpload() {
-    $base_path = Yii::getAlias('@app');
-    $web_path = Yii::getAlias('@web');
-    $model = new UploadForm();
-
-    if (Yii::$app->request->isPost) {
-        $model->file = UploadedFile::getInstanceByName('file');
-
-        if ($model->validate()) {
-            $model->file->saveAs($base_path . '/web/uploads/' . $model->file->baseName . '.' . $model->file->extension);
-        }
-    }
-
-    // Get file link
-    $res = [
-        'link' => $web_path . '/uploads/' . $model->file->baseName . '.' . $model->file->extension,
-    ];
-
-    // Response data
-    Yii::$app->response->format = Yii::$app->response->format = Response::FORMAT_JSON;
-    return $res;
-}
-```
-
-For model: 
+Using the Froala PHP SDK with Froala Editor widget, the first step would be to add the configuration in web.php config file, make an entry for Froala Module
+in the Config Array.
 
 ```php
-namespace app\models;
-use yii\base\Model;
-use yii\web\UploadedFile;
-
-/**
- * UploadForm is the model behind the upload form.
- */
-class UploadForm extends Model
-{
-    /**
-     * @var UploadedFile|Null file attribute
-     */
-    public $file;
-
-    /**
-     * @return array the validation rules.
-     */
-    public function rules()
-    {
-        return [
-            [['file'], 'file']
-        ];
-    }
-}
+'modules' => [
+        'froala' => [
+            'class' => '\froala\froalaeditor\Module',
+            'uploadFolder' => '/uploads/'
+        ]
+    ],
 ```
 
-For the view:
+Make sure you have a folder called "uploads" in your web root directory,Now to use the Froala Widget on any view just use the following code in the view:
 
 ```php
 <?= \froala\froalaeditor\FroalaEditorWidget::widget([
@@ -132,8 +91,7 @@ For the view:
         'theme' => 'royal',//optional: dark, red, gray, royal
         'language' => 'en_gb' ,
         'toolbarButtons' => ['fullscreen', 'bold', 'italic', 'underline', '|', 'paragraphFormat', 'insertImage'],
-        'imageUploadParam' => 'file',
-        'imageUploadURL' => \yii\helpers\Url::to(['site/upload/'])
+        'imageUploadParam' => 'file'
     ],
     'clientPlugins'=> ['fullscreen', 'paragraph_format', 'image']
 ]); ?>

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "require": {
         "yiisoft/yii2": "^2.0",
         "rmrevin/yii2-fontawesome": "^2.0",
-        "froala/wysiwyg-editor-php-sdk": "*"
+        "froala/wysiwyg-editor-php-sdk": "*",
+        "bower-asset/froala-wysiwyg-editor": "^2.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     ],
     "require": {
         "yiisoft/yii2": "^2.0",
-        "bower-asset/froala-wysiwyg-editor": "^2.6.0",
         "rmrevin/yii2-fontawesome": "*",
         "froala/wysiwyg-editor-php-sdk": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,9 @@
     ],
     "require": {
         "yiisoft/yii2": "^2.0",
-        "froala/wysiwyg-editor": "^2.6.0",
-        "rmrevin/yii2-fontawesome": "^2.0"
+        "bower-asset/froala-wysiwyg-editor": "^2.6.0",
+        "rmrevin/yii2-fontawesome": "*",
+        "froala/wysiwyg-editor-php-sdk": "*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "yiisoft/yii2": "^2.0",
-        "rmrevin/yii2-fontawesome": "*",
+        "rmrevin/yii2-fontawesome": "^2.0",
         "froala/wysiwyg-editor-php-sdk": "*"
     },
     "autoload": {

--- a/src/FroalaEditorWidget.php
+++ b/src/FroalaEditorWidget.php
@@ -110,4 +110,14 @@ class FroalaEditorWidget extends InputWidget
 
         $view->registerJs("\$('#$id').froalaEditor($jsOptions);");
     }
+
+	public static function widget($config = [])
+	{
+		if (!isset($config['clientOptions']['imageUploadURL']))
+		{
+			$config['clientOptions']['imageUploadURL'] = \yii\helpers\Url::to(['froala/default/upload']);
+		}
+
+		return parent::widget($config);
+	}
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace froala\froalaeditor;
+
+class Module extends \yii\base\Module
+{
+	public $controllerNamespace = 'froala\froalaeditor\controllers';
+
+	// Without false it will give "Bad Request (#400) Unable to verify your data submission."
+	public $enableCsrfValidation = false;
+
+	public $uploadFolder;
+}

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace froala\froalaeditor\controllers;
+
+use yii\web\Controller;
+
+class DefaultController extends Controller
+{
+	// Without false it will give "Bad Request (#400) Unable to verify your data submission."
+	public $enableCsrfValidation = false;
+
+    public function actionUpload()
+    {
+		// Store the image.
+	    try {
+			$uploadFolder = $this->module->uploadFolder;
+
+		    $response = \FroalaEditor_Image::upload($uploadFolder);
+		    echo stripslashes(json_encode($response));
+	    }
+	    catch (Exception $e) {
+		    http_response_code(404);
+	    }
+
+    }
+}

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -7,7 +7,7 @@ use yii\web\Controller;
 class DefaultController extends Controller
 {
 	// Without false it will give "Bad Request (#400) Unable to verify your data submission."
-	public $enableCsrfValidation = false;
+    public $enableCsrfValidation = false;
 
     public function actionUpload()
     {


### PR DESCRIPTION
This PR focuses on changes that would add a default controller to the plugin so we can perform actions like imageUploadURL by using Froala's PHP SDK, load it through the yii routes, unlike before where we had to write a custom Controller uploadAction and Model changes, all we need is to setup a module configuration inside web.php config array and then the upload folder path could be fetched from that. 